### PR TITLE
update ART data schema to 'calendar_quarter' and remove 'art_new'

### DIFF
--- a/table_schemas/art/3_art_inputs.json
+++ b/table_schemas/art/3_art_inputs.json
@@ -40,7 +40,7 @@
       "description": "The calendar quarter reflected the end of reporting period. Formatted as CY20XXQY, for example CY2020Q4 for end of December 2020.",
       "type": "string",
       "constraints": {
-          "required": true,
+          "required": true
       }
     },
     {

--- a/table_schemas/art/3_art_inputs.json
+++ b/table_schemas/art/3_art_inputs.json
@@ -35,14 +35,12 @@
       }
     },
     {
-      "name": "year",
-      "title": "Year",
-      "description": "The year.",
-      "type": "integer",
+      "name": "calendar_quarter",
+      "title": "Calendar Quarter",
+      "description": "The calendar quarter reflected the end of reporting period. Formatted as CY20XXQY, for example CY2020Q4 for end of December 2020.",
+      "type": "string",
       "constraints": {
           "required": true,
-          "minimum": 1970,
-          "maximum": 2021
       }
     },
     {
@@ -54,20 +52,10 @@
         "required": true,
         "minimum": 0
       }
-    },
-    {
-       "name": "art_new",
-       "title": "Number newly initiating ART",
-       "description": "Number newly initiating ART during the reporting period (year).",
-       "type": "number",
-       "constraints": {
-         "required": false,
-         "minimum": 0
-       }
     }
   ],
   "require_field_order": false,
-  "primaryKey": ["area_id", "sex", "age_group", "year"],
+  "primaryKey": ["area_id", "sex", "age_group", "calendar_quarter"],
   "title": "UNAIDS ART Programme Input",
   "version": "2.0",
   "description": "If data does not exist, please indicate so with the value \"NA\" and ignore any warning given by Excel."


### PR DESCRIPTION
This PR updates the ART input data schema reflecting discussion on call today:

* Change the column `year` to `calendar_quarter`.
* Drop the `art_new` column from this dataset. As discussed -- those will be saved separately in the ADR to be accessed when needed.

For validation on the `calendar_quarter` column, I'm not sure if it's possible to do (e.g. validation against a regex) and if so how to specify. 

For the `art_new` dataset, I haven't specified any schema and I think it can be a bit flexible. But generally useful to have it easily linkable + columns for the period end and period duration. And as discussed ideally saved in at the most granular stratification recorded.

Let me know if this looks different than expected and happy to discuss more.

Thanks,
Jeff