### PR TITLE
ADX-481 Add the ability to tag resources in general datasets.

### DIFF
--- a/package_schemas/general_data/1_restricted_schema.json
+++ b/package_schemas/general_data/1_restricted_schema.json
@@ -122,6 +122,12 @@
             "label": "Access Restriction",
             "preset": "restricted_fields",
             "display_group": "Access Restriction"
+        },
+        {
+            "field_name": "tag_string",
+            "label": "Tags",
+            "preset": "tag_string_autocomplete",
+            "form_placeholder": "eg. economy, mental health, government"
         }
     ]
 }

--- a/package_schemas/general_data/2_restricted_schema.json
+++ b/package_schemas/general_data/2_restricted_schema.json
@@ -102,6 +102,12 @@
             "label": "Access Restriction",
             "preset": "restricted_fields",
             "display_group": "Access Restriction"
+        },
+        {
+            "field_name": "tag_string",
+            "label": "Tags",
+            "preset": "tag_string_autocomplete",
+            "form_placeholder": "eg. economy, mental health, government"
         }
     ]
 }


### PR DESCRIPTION
Just a small schema change that adds a tag_string field to each individual resource in the general dataset. 

Requires no data migration. 

Requested by ian and mary as a matter of urgency for advanced shiny rob use. So the user can tag resources as "ART" or "ANC". 

Would be great if we can get to production asap. 

