### PR TITLE
Adx 518 move dataset transfer button to bottom

### DIFF
--- a/package_schemas/document_archive/1_document_archive.json
+++ b/package_schemas/document_archive/1_document_archive.json
@@ -44,11 +44,7 @@
             "field_name": "owner_org",
             "label": "Organization",
             "preset": "dataset_organization"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
+        },        
         {
             "field_name": "maintainer",
             "label": "Maintainer",
@@ -68,6 +64,10 @@
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "Document Archive"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/general_data/1_restricted_schema.json
+++ b/package_schemas/general_data/1_restricted_schema.json
@@ -39,11 +39,7 @@
             "field_name": "owner_org",
             "label": "Organization",
             "preset": "dataset_organization"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
+        },        
         {
             "field_name": "url",
             "label": "Source",
@@ -97,6 +93,10 @@
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "General Data"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/general_data/2_restricted_schema.json
+++ b/package_schemas/general_data/2_restricted_schema.json
@@ -50,11 +50,7 @@
             "preset": "dataset_organization",
             "private": false,
             "visibility_classes": ["hidden"]
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
+        },        
         {
             "field_name": "maintainer",
             "label": "Contact Name",
@@ -77,6 +73,10 @@
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "General Data"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/geographic_data/1_geographic_data.json
+++ b/package_schemas/geographic_data/1_geographic_data.json
@@ -52,11 +52,7 @@
             "field_name": "owner_org",
             "label": "Organization",
             "preset": "dataset_organization"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
+        },        
         {
             "field_name": "url",
             "label": "Source",
@@ -89,6 +85,10 @@
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "Geographic Data"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resources": [{

--- a/package_schemas/geographic_data/2_geographic_data.json
+++ b/package_schemas/geographic_data/2_geographic_data.json
@@ -87,16 +87,16 @@
             "field_name": "owner_org",
             "label": "Organization",
             "preset": "dataset_organization"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
+        },        
         {
             "label": "Data Type",
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "Geographic Data"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resources": [{

--- a/package_schemas/inputs_unaids_estimates/1_inputs_unaids_estimates.json
+++ b/package_schemas/inputs_unaids_estimates/1_inputs_unaids_estimates.json
@@ -87,12 +87,7 @@
             "private": false,
             "visibility_classes": ["hidden"],
             "display_group": "Inputs to UNAIDS Estimates 2021"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to",
-            "display_group": "Inputs to UNAIDS Estimates 2021"
-        },
+        },        
         {
             "label": "Year",
             "field_name": "year",
@@ -107,6 +102,11 @@
             "preset": "hidden_value",
             "field_value": "Inputs to UNAIDS Estimates",
             "validators": "unique_combination",
+            "display_group": "Inputs to UNAIDS Estimates 2021"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to",
             "display_group": "Inputs to UNAIDS Estimates 2021"
         }
     ],

--- a/package_schemas/naomi_data/1_naomi_data.json
+++ b/package_schemas/naomi_data/1_naomi_data.json
@@ -96,12 +96,7 @@
       "private": false,
       "visibility_classes": ["hidden"],
       "display_group": "Naomi Data Package"
-    },
-    {
-      "field_name": "org_to_allow_transfer_to",
-      "preset": "org_to_allow_transfer_to",
-      "display_group": "Naomi Data Package"
-    },
+    },    
     {
       "label": "Data Type",
       "field_name": "type_name",
@@ -109,6 +104,11 @@
       "field_value": "Naomi Data",
       "validators": "unique_combination",
       "display_group": "Naomi Inputs and Outputs"
+    },
+    {
+      "field_name": "org_to_allow_transfer_to",
+      "preset": "org_to_allow_transfer_to",
+      "display_group": "Naomi Data Package"
     }
   ],
   "resources": [{

--- a/package_schemas/naomi_data/2_naomi_data_abidjan.json
+++ b/package_schemas/naomi_data/2_naomi_data_abidjan.json
@@ -95,18 +95,18 @@
             "private": false,
             "visibility_classes": ["hidden"],
             "display_group": "Naomi Data Package"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to",
-            "display_group": "Naomi Data Package"
-        },
+        },        
         {
             "label": "Data Type",
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "Naomi Inputs and Outputs",
             "validators": "unique_combination",
+            "display_group": "Naomi Data Package"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to",
             "display_group": "Naomi Data Package"
         }
     ],

--- a/package_schemas/population_data/1_population_data.json
+++ b/package_schemas/population_data/1_population_data.json
@@ -51,11 +51,7 @@
             "field_name": "owner_org",
             "label": "Organization",
             "preset": "dataset_organization"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
+        },        
         {
             "field_name": "url",
             "label": "Source",
@@ -88,6 +84,10 @@
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "Population Data"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resources": [{

--- a/package_schemas/population_data/2_population_data.json
+++ b/package_schemas/population_data/2_population_data.json
@@ -88,14 +88,14 @@
             "preset": "dataset_organization"
         },
         {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
-        {
             "label": "Data Type",
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "Population Data"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resources": [{

--- a/package_schemas/programmatic_data/1_programmatic_data.json
+++ b/package_schemas/programmatic_data/1_programmatic_data.json
@@ -52,11 +52,7 @@
             "field_name": "owner_org",
             "label": "Organization",
             "preset": "dataset_organization"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
+        },        
         {
             "field_name": "url",
             "label": "Source",
@@ -89,6 +85,10 @@
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "Programmatic Data"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resources": [{

--- a/package_schemas/programmatic_data/2_programmatic_data.json
+++ b/package_schemas/programmatic_data/2_programmatic_data.json
@@ -87,16 +87,16 @@
             "field_name": "owner_org",
             "label": "Organization",
             "preset": "dataset_organization"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
+        },        
         {
             "label": "Data Type",
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "Programmatic Data"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resources": [{

--- a/package_schemas/spectrum_file/1_spectrum_file.json
+++ b/package_schemas/spectrum_file/1_spectrum_file.json
@@ -51,11 +51,7 @@
             "field_name": "owner_org",
             "label": "Organization",
             "preset": "dataset_organization"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
+        },        
         {
             "field_name": "url",
             "label": "Source",
@@ -88,6 +84,10 @@
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "Spectrum File"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/spectrum_file/2_spectrum_file.json
+++ b/package_schemas/spectrum_file/2_spectrum_file.json
@@ -86,16 +86,16 @@
             "field_name": "owner_org",
             "label": "Organization",
             "preset": "dataset_organization"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
+        },        
         {
             "label": "Data Type",
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "Spectrum File"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/survey_data/1_survey_data.json
+++ b/package_schemas/survey_data/1_survey_data.json
@@ -52,11 +52,7 @@
             "field_name": "owner_org",
             "label": "Organization",
             "preset": "dataset_organization"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
+        },        
         {
             "field_name": "url",
             "label": "Source",
@@ -89,6 +85,10 @@
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "Survey Data"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/survey_data/2_survey_data.json
+++ b/package_schemas/survey_data/2_survey_data.json
@@ -87,16 +87,16 @@
             "field_name": "owner_org",
             "label": "Organization",
             "preset": "dataset_organization"
-        },
-        {
-            "field_name": "org_to_allow_transfer_to",
-            "preset": "org_to_allow_transfer_to"
-        },
+        },        
         {
             "label": "Data Type",
             "field_name": "type_name",
             "preset": "hidden_value",
             "field_value": "Survey Data"
+        },
+        {
+            "field_name": "org_to_allow_transfer_to",
+            "preset": "org_to_allow_transfer_to"
         }
     ],
     "resource_fields": [{


### PR DESCRIPTION
# Problem
- A lot of datasets show the Dataset Transfer button in the middle of the form

# Solution
- Shuffle it to the very bottom of the schema config so it's always at the bottom