### PR TITLE
Set n_clusters field to be optional.

### DIFF
--- a/table_schemas/survey_indicators/3_survey_inputs.json
+++ b/table_schemas/survey_indicators/3_survey_inputs.json
@@ -68,10 +68,7 @@
       "name": "n_clusters",
       "title": "Number of clusters",
       "description": "The number of survey clusters",
-      "type": "integer",
-      "constraints": {
-        "required": true
-      }
+      "type": "integer"
     },
     {
       "name": "n_observations",


### PR DESCRIPTION
@jeffeaton has confirmed that the n_clusters field should be optional. This removes the required constraint from the field. 