### PR TITLE
ADX-762 VLS data for the ART table

### DIFF
--- a/package_schemas/country_estimates/2_country_estimates_22.json
+++ b/package_schemas/country_estimates/2_country_estimates_22.json
@@ -167,7 +167,7 @@
             }, {
                 "field_name": "schema",
                 "preset": "hidden_value",
-                "field_value": "3_art_inputs"
+                "field_value": "4_art_estimates"
             }, {
                 "field_name": "resource_type",
                 "preset": "hidden_value",

--- a/table_schemas/art/4_art_estimates.json
+++ b/table_schemas/art/4_art_estimates.json
@@ -1,0 +1,89 @@
+{
+  "fields": [{
+      "name": "area_id",
+      "title": "Area ID",
+      "description": "Must be an area_id from the agreed area hierarchy.",
+      "type": "string",
+      "constraints": {
+        "required": true
+      }
+    },
+    {
+      "name": "area_name",
+      "title": "Area Name",
+      "description": "Area name corresponding to area_id (optional).",
+      "type": "string"
+    },
+    {
+      "name": "sex",
+      "title": "Sex",
+      "description": "Biological sex.  Must be \"both\", \"female\", or \"male\".",
+      "type": "string",
+      "constraints": {
+        "required": true,
+          "enum": ["both", "male", "female"]
+      }
+    },
+    {
+      "name": "age_group",
+      "title": "Age Group",
+      "description": "The age group. Must be either \"Y000_014\" (0-14 y), \"Y015_999\" (15+ y) or \"Y000_999\" (0+). ",
+      "type": "string",
+      "constraints": {
+        "required": true,
+        "enum": ["Y000_014", "Y015_999", "Y000_999"]
+      }
+    },
+    {
+      "name": "calendar_quarter",
+      "title": "Calendar Quarter",
+      "description": "The calendar quarter reflected the end of reporting period. Formatted as CY20XXQY, for example CY2020Q4 for end of December 2020.",
+      "type": "string",
+      "constraints": {
+          "required": true
+      }
+    },
+    {
+      "name": "art_current",
+      "title": "Number on ART",
+      "description": "Number currently receiving ART at the end of reporting period (year).",
+      "type": "number",
+      "constraints": {
+        "required": true,
+        "minimum": 0
+      }
+    },
+    {
+      "name": "vls_tested",
+      "title": "Number VLS Tested",
+      "description": "The number of people tested for viral load suppression during the reporting period.",
+      "type": "number",
+      "constraints": {
+        "required": true,
+        "minimum": 0
+      }
+    },
+    {
+      "name": "vls_suppressed",
+      "title": "Number VLS",
+      "description": "The number of people who tested positive during the reporting period for supressed viral loads",
+      "type": "number",
+      "constraints": {
+        "required": true,
+        "minimum": 0
+      }
+    }
+  ],
+  "foreignKeys": [{
+    "fields": "area_id",
+    "reference": {
+      "resource": "3_geojson_inputs",
+      "fields": "area_id"
+    }
+  }],
+  "require_field_order": false,
+  "primaryKey": ["area_id", "sex", "age_group", "calendar_quarter"],
+  "title": "UNAIDS ART Programme Input",
+  "version": "2.1",
+  "description": "If data does not exist, please indicate so with the value \"NA\" and ignore any warning given by Excel."
+}

--- a/table_schemas/art/4_art_estimates.json
+++ b/table_schemas/art/4_art_estimates.json
@@ -56,7 +56,7 @@
     {
       "name": "vls_tested",
       "title": "Number VLS Tested",
-      "description": "The number of people who received a routine viral load test during the reporting period.",
+      "description": "The number of people who received a routine viral load test during the 12 months prior to the reporting period end date.",
       "type": "number",
       "constraints": {
         "required": true,
@@ -66,7 +66,7 @@
     {
       "name": "vls_suppressed",
       "title": "Number VLS",
-      "description": "The number of people who were virally suppressed among those who received a routine viral load test during the period.",
+      "description": "The number of people who were virally suppressed among those who received a routine viral load test during the 12 months prior to the reporting period end date.",
       "type": "number",
       "constraints": {
         "required": true,

--- a/table_schemas/art/4_art_estimates.json
+++ b/table_schemas/art/4_art_estimates.json
@@ -54,7 +54,7 @@
       }
     },
     {
-      "name": "vls_tested",
+      "name": "vl_tested_12mos",
       "title": "Number VLS Tested",
       "description": "The number of people who received a routine viral load test during the 12 months prior to the reporting period end date.",
       "type": "number",
@@ -64,7 +64,7 @@
       }
     },
     {
-      "name": "vls_suppressed",
+      "name": "vl_suppressed_12mos",
       "title": "Number VLS",
       "description": "The number of people who were virally suppressed among those who received a routine viral load test during the 12 months prior to the reporting period end date.",
       "type": "number",

--- a/table_schemas/art/4_art_estimates.json
+++ b/table_schemas/art/4_art_estimates.json
@@ -35,21 +35,37 @@
       }
     },
     {
+      "name": "year",
+      "title": "Year",
+      "description": "The year in which data was collected.",
+      "type": "integer",
+      "constraints": {
+          "minimum": 1970,
+          "maximum": 2022
+      }
+    },
+    {
       "name": "calendar_quarter",
       "title": "Calendar Quarter",
       "description": "The calendar quarter reflected the end of reporting period. Formatted as CY20XXQY, for example CY2020Q4 for end of December 2020.",
-      "type": "string",
-      "constraints": {
-          "required": true
-      }
+      "type": "string"
     },
     {
       "name": "art_current",
       "title": "Number on ART",
-      "description": "Number currently receiving ART at the end of reporting period (year).",
+      "description": "Number currently receiving ART at the end of reporting period.",
       "type": "number",
       "constraints": {
         "required": true,
+        "minimum": 0
+      }
+    },
+    {
+      "name": "art_new",
+      "title": "Number newly initiated on ART",
+      "description": "Number newly initiated on ART during reporting period",
+      "type": "number",
+      "constraints": {
         "minimum": 0
       }
     },
@@ -59,7 +75,6 @@
       "description": "The number of people who received a routine viral load test during the 12 months prior to the reporting period end date.",
       "type": "number",
       "constraints": {
-        "required": true,
         "minimum": 0
       }
     },
@@ -69,7 +84,6 @@
       "description": "The number of people who were virally suppressed among those who received a routine viral load test during the 12 months prior to the reporting period end date.",
       "type": "number",
       "constraints": {
-        "required": true,
         "minimum": 0
       }
     }
@@ -87,8 +101,8 @@
       "fields": "area_id"
     }
   }],
-  "require_field_order": false,
-  "primaryKey": ["area_id", "sex", "age_group", "calendar_quarter"],
+  "require_field_order": true,
+  "primaryKey": ["area_id", "sex", "age_group", "calendar_quarter", "year"],
   "title": "UNAIDS ART Programme Input",
   "version": "4",
   "description": "If data does not exist, please indicate so with the value \"NA\" and ignore any warning given by Excel."

--- a/table_schemas/art/4_art_estimates.json
+++ b/table_schemas/art/4_art_estimates.json
@@ -84,6 +84,6 @@
   "require_field_order": false,
   "primaryKey": ["area_id", "sex", "age_group", "calendar_quarter"],
   "title": "UNAIDS ART Programme Input",
-  "version": "2.1",
+  "version": "4",
   "description": "If data does not exist, please indicate so with the value \"NA\" and ignore any warning given by Excel."
 }

--- a/table_schemas/art/4_art_estimates.json
+++ b/table_schemas/art/4_art_estimates.json
@@ -74,6 +74,12 @@
       }
     }
   ],
+  "customConstraints": [
+    {
+      "constraint": "vls_tested >= vls_suppressed",
+      "description": "The total number of people who recieved a routine viral load test must be greater than the number among them who were virally supressed."
+    }
+  ],
   "foreignKeys": [{
     "fields": "area_id",
     "reference": {

--- a/table_schemas/art/4_art_estimates.json
+++ b/table_schemas/art/4_art_estimates.json
@@ -56,7 +56,7 @@
     {
       "name": "vls_tested",
       "title": "Number VLS Tested",
-      "description": "The number of people tested for viral load suppression during the reporting period.",
+      "description": "The number of people who received a routine viral load test during the reporting period.",
       "type": "number",
       "constraints": {
         "required": true,
@@ -66,7 +66,7 @@
     {
       "name": "vls_suppressed",
       "title": "Number VLS",
-      "description": "The number of people who tested positive during the reporting period for supressed viral loads",
+      "description": "The number of people who were virally suppressed among those who received a routine viral load test during the period.",
       "type": "number",
       "constraints": {
         "required": true,


### PR DESCRIPTION
Adding vls_tested and vls_suppression into the ART data template. 

I take it we are not going to enforce the `vls_tested > vls_supression` constraint? 