### PR TITLE
ADX-983 Counts can be non-integer

### DIFF
--- a/table_schemas/shiny90_survey/1_shiny90_survey_estimates.json
+++ b/table_schemas/shiny90_survey/1_shiny90_survey_estimates.json
@@ -106,7 +106,7 @@
             "name": "Counts",
             "title": "Counts",
             "description": "Unweighted counts of the number of survey respondents included in the stratification group",
-            "type": "integer",
+            "type": "number",
             "constraints": {
                 "minimum": 0
             }


### PR DESCRIPTION
## Description

From Jeff...

Hi Jonathan,

ADR is doing a check that the ‘Counts’ column in the Shiny90 Survey data set is an integer (column 11, example error message here: https://adr.unaids.org/country-estimates-23/eswatini-country-estimates-2023/resource/501941d2-9550-4a0d-8c8c-c0c768c693f9).  This is unnecessarily restrictive and inconsequential as this field is not actually used in the model. It can be any numeric.  Is it easy to relax that check?

Thanks,
Jeff 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [x] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [x] New dependency changes have been committed.
- [x] I have added automated tests that prove my fix is effective or that my feature works.
- [x] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
