### PR TITLE
ADX-949 revert how foreign keys are handled

### DIFF
--- a/table_schemas/anc/5_anc_frictionlessv5.json
+++ b/table_schemas/anc/5_anc_frictionlessv5.json
@@ -106,7 +106,7 @@
     {
       "fields": "area_id",
       "reference": {
-        "resource": "inputs-unaids-geographic",
+        "resource": "4_geojson_frictionlessv5",
         "fields": "area_id"
       }
     }

--- a/table_schemas/art/5_art_frictionlessv5.json
+++ b/table_schemas/art/5_art_frictionlessv5.json
@@ -89,7 +89,7 @@
     {
       "fields": "area_id",
       "reference": {
-        "resource": "inputs-unaids-geographic",
+        "resource": "4_geojson_frictionlessv5",
         "fields": "area_id"
       }
     }

--- a/table_schemas/population/4_population_frictionlessv5.json
+++ b/table_schemas/population/4_population_frictionlessv5.json
@@ -72,7 +72,7 @@
     {
       "fields": "area_id",
       "reference": {
-        "resource": "inputs-unaids-geographic",
+        "resource": "4_geojson_frictionlessv5",
         "fields": "area_id"
       }
     }

--- a/table_schemas/survey_indicators/3_survey_inputs.json
+++ b/table_schemas/survey_indicators/3_survey_inputs.json
@@ -128,7 +128,7 @@
     {
       "fields": "area_id",
       "reference": {
-        "resource": "inputs-unaids-geographic",
+        "resource": "4_geojson_frictionlessv5",
         "fields": "area_id"
       }
     }

--- a/table_schemas/survey_indicators/4_survey_frictionlessv5.json
+++ b/table_schemas/survey_indicators/4_survey_frictionlessv5.json
@@ -128,7 +128,7 @@
     {
       "fields": "area_id",
       "reference": {
-        "resource": "inputs-unaids-geographic",
+        "resource": "4_geojson_frictionlessv5",
         "fields": "area_id"
       }
     }


### PR DESCRIPTION
## Description

As detailed in fjelltopp/ckanext-validation#103 and related PRs I fundamentally changed how foreign keys are denoted - at the time this felt like the only solution that was a) general, and so could be pushed upstream, and b) worked with only a minor change to our current approach. However, yesterday it suddenly dawned on me that this actually completely broke our current approach.

The attached is a patch that reimplements some logic from our old fork to solve this problem.

relates fjelltopp/ckanext-validation#105

## Checklist

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
