### PR TITLE
fix: revert accidental update of 3_survey_inputs foreign key

### DIFF
--- a/table_schemas/survey_indicators/3_survey_inputs.json
+++ b/table_schemas/survey_indicators/3_survey_inputs.json
@@ -128,7 +128,7 @@
     {
       "fields": "area_id",
       "reference": {
-        "resource": "4_geojson_frictionlessv5",
+        "resource": "3_geojson_inputs",
         "fields": "area_id"
       }
     }


### PR DESCRIPTION
## Description

Whilst resetting resource schema files in order to test the new validation extension I noted that the foreign key field in the Survey Data schema for 2023 estimates had been incorrectly changed to "4_geojson_frictionlessv5" when the geojson resource for 2023 estimates should still be "3_geojson_inputs" - this corrects that.

## Checklist

- [x] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [x] I have developed these changes in discussion with the appropriate project manager.
- [x] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [x] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own code.
- [x] I have assigned at least one reviewer.
