### PR TITLE
ADX-1020 Rename the geo-dataset type

### DIFF
--- a/package_schemas/geographic_data/3_geographic_data.json
+++ b/package_schemas/geographic_data/3_geographic_data.json
@@ -1,7 +1,7 @@
 {
     "scheming_version": 1,
     "dataset_type": "geographic-data-package-3",
-    "name": "Administrative Boundaries",
+    "name": "Geographic Data",
     "about": "",
     "about_url": "http://github.com/ckan/ckanext-scheming",
     "display_group_order": ["General", "Access Restriction"],


### PR DESCRIPTION
## Description

Ian says he wants us to refer to the published geographic data as "Geographic Health Boundaries" instead of "Administrative boundaries". 

This small change just removes the references to "Administrative boundaries" and ensures that the "Geographic Data" type is consistent across versions. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
