### PR TITLE
ADX-854 Add locked metadata element

### DIFF
--- a/package_schemas/country_estimates/1_country_estimates_21.json
+++ b/package_schemas/country_estimates/1_country_estimates_21.json
@@ -108,6 +108,10 @@
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to",
             "display_group": "Inputs to UNAIDS Estimates 2021"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resources": [

--- a/package_schemas/country_estimates/2_country_estimates_22.json
+++ b/package_schemas/country_estimates/2_country_estimates_22.json
@@ -108,6 +108,10 @@
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to",
             "display_group": "HIV Estimates 2022"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resources": [

--- a/package_schemas/country_estimates/3_country_estimates_23.json
+++ b/package_schemas/country_estimates/3_country_estimates_23.json
@@ -108,6 +108,10 @@
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to",
             "display_group": "HIV Estimates 2023"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resources": [

--- a/package_schemas/country_estimates/4_country_estimates_24.json
+++ b/package_schemas/country_estimates/4_country_estimates_24.json
@@ -109,6 +109,10 @@
       "field_name": "org_to_allow_transfer_to",
       "preset": "org_to_allow_transfer_to",
       "display_group": "HIV Estimates 2024"
+    },
+    {
+      "field_name": "locked",
+      "preset": "locked"
     }
   ],
   "resources": [

--- a/package_schemas/document_archive/1_document_archive.json
+++ b/package_schemas/document_archive/1_document_archive.json
@@ -68,6 +68,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/general_data/1_restricted_schema.json
+++ b/package_schemas/general_data/1_restricted_schema.json
@@ -97,6 +97,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/general_data/2_restricted_schema.json
+++ b/package_schemas/general_data/2_restricted_schema.json
@@ -77,6 +77,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/geographic_data/1_geographic_data.json
+++ b/package_schemas/geographic_data/1_geographic_data.json
@@ -89,6 +89,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resources": [{

--- a/package_schemas/geographic_data/2_geographic_data.json
+++ b/package_schemas/geographic_data/2_geographic_data.json
@@ -97,6 +97,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resources": [{

--- a/package_schemas/geographic_data/3_geographic_data.json
+++ b/package_schemas/geographic_data/3_geographic_data.json
@@ -76,6 +76,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/naomi_data/1_naomi_data.json
+++ b/package_schemas/naomi_data/1_naomi_data.json
@@ -109,6 +109,10 @@
       "field_name": "org_to_allow_transfer_to",
       "preset": "org_to_allow_transfer_to",
       "display_group": "Naomi Data Package"
+    },
+    {
+      "field_name": "locked",
+      "preset": "locked"
     }
   ],
   "resources": [{

--- a/package_schemas/naomi_data/2_naomi_data_abidjan.json
+++ b/package_schemas/naomi_data/2_naomi_data_abidjan.json
@@ -108,6 +108,10 @@
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to",
             "display_group": "Naomi Data Package"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resources": [{

--- a/package_schemas/population_data/1_population_data.json
+++ b/package_schemas/population_data/1_population_data.json
@@ -88,6 +88,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resources": [{

--- a/package_schemas/population_data/2_population_data.json
+++ b/package_schemas/population_data/2_population_data.json
@@ -96,6 +96,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resources": [{

--- a/package_schemas/programmatic_data/1_programmatic_data.json
+++ b/package_schemas/programmatic_data/1_programmatic_data.json
@@ -89,6 +89,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resources": [{

--- a/package_schemas/programmatic_data/2_programmatic_data.json
+++ b/package_schemas/programmatic_data/2_programmatic_data.json
@@ -97,6 +97,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resources": [{

--- a/package_schemas/programmatic_data/3_programmatic_data.json
+++ b/package_schemas/programmatic_data/3_programmatic_data.json
@@ -97,6 +97,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resources": [{

--- a/package_schemas/spectrum_file/1_spectrum_file.json
+++ b/package_schemas/spectrum_file/1_spectrum_file.json
@@ -88,6 +88,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/spectrum_file/2_spectrum_file.json
+++ b/package_schemas/spectrum_file/2_spectrum_file.json
@@ -96,6 +96,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/survey_data/1_survey_data.json
+++ b/package_schemas/survey_data/1_survey_data.json
@@ -89,6 +89,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resource_fields": [{

--- a/package_schemas/survey_data/2_survey_data.json
+++ b/package_schemas/survey_data/2_survey_data.json
@@ -97,6 +97,10 @@
         {
             "field_name": "org_to_allow_transfer_to",
             "preset": "org_to_allow_transfer_to"
+        },
+        {
+          "field_name": "locked",
+          "preset": "locked"
         }
     ],
     "resource_fields": [{


### PR DESCRIPTION
## Description

This PR adds the locked metadata element to every package schema.  This is needed in order for the dataset locking feature to work properly.

Relates to: https://github.com/fjelltopp/ckanext-unaids/pull/310

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
