### PR TITLE
ADX-1071 Update maximum year in shiny90 and hivtesting table schemas

### DIFF
--- a/table_schemas/hiv_testing/1_hiv_testing_inputs.json
+++ b/table_schemas/hiv_testing/1_hiv_testing_inputs.json
@@ -12,12 +12,12 @@
         {
             "name": "Year",
             "title": "Year",
-            "description": "The calendar year e.g. 2022",
+            "description": "The calendar year e.g. 2023",
             "type": "integer",
             "constraints": {
                 "required": true,
                 "minimum": 1970,
-                "maximum": 2022
+                "maximum": 2023
             }
         },
         {

--- a/table_schemas/shiny90_survey/1_shiny90_survey_estimates.json
+++ b/table_schemas/shiny90_survey/1_shiny90_survey_estimates.json
@@ -26,7 +26,7 @@
             "constraints": {
                 "required": true,
                 "minimum": 1970,
-                "maximum": 2022
+                "maximum": 2023
             }
         },
         {


### PR DESCRIPTION
## Description

Makini from Mozambique reported that shiny90 and hiv testing validation is failing.  This PR just makes sure that we update all live schemas used in this years estimates process to accept 2023 data. 

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
