### PR TITLE
ADX-1073 Updated metadata of two new extra VMMC core resources.

### DIFF
--- a/package_schemas/country_estimates/4_country_estimates_24.json
+++ b/package_schemas/country_estimates/4_country_estimates_24.json
@@ -421,14 +421,14 @@
       ]
     },
     {
-      "name": "VMMC Excel Workbook",
-      "about": "VMMC Workbook data",
-      "resource_type": "inputs-unaids-vmmc-workbook",
+      "name": "VMMC Outputs",
+      "about": "VMMC Outputs Excel Workbook",
+      "resource_type": "inputs-unaids-vmmc-coverage-outputs",
       "resource_fields": [
         {
           "field_name": "name",
           "preset": "hidden_value",
-          "field_value": "VMMC Excel Workbook"
+          "field_value": "VMMC Outputs"
         },
         {
           "field_name": "format",
@@ -439,7 +439,30 @@
         {
           "field_name": "resource_type",
           "preset": "hidden_value",
-          "field_value": "inputs-unaids-vmmc-workbook"
+          "field_value": "inputs-unaids-vmmc-coverage-outputs"
+        }
+      ]
+    },
+    {
+      "name": "VMMC Inputs",
+      "about": "VMMC Inputs Excel Workbook",
+      "resource_type": "inputs-unaids-vmmc-coverage-inputs",
+      "resource_fields": [
+        {
+          "field_name": "name",
+          "preset": "hidden_value",
+          "field_value": "VMMC Inputs"
+        },
+        {
+          "field_name": "format",
+          "label": "Format",
+          "preset": "resource_format_autocomplete",
+          "default": "XLSX"
+        },
+        {
+          "field_name": "resource_type",
+          "preset": "hidden_value",
+          "field_value": "inputs-unaids-vmmc-coverage-inputs"
         }
       ]
     }


### PR DESCRIPTION
## Description

After review a request was made to include two new extra VMMC resources. The resource types were changes to: "inputs-unaids-vmmc-coverage-outputs" and "inputs-unaids-vmmc-coverage-inputs"

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
