### PR TITLE
ADX-1085 Remove shiny zip as a required resource

### DIFF
--- a/package_schemas/country_estimates/4_country_estimates_24.json
+++ b/package_schemas/country_estimates/4_country_estimates_24.json
@@ -306,29 +306,6 @@
       ]
     },
     {
-      "name": "Shiny90 Output ZIP",
-      "about": "The Shiny90 output zip file",
-      "resource_type": "inputs-unaids-shiny90-output-zip",
-      "resource_fields": [
-        {
-          "field_name": "name",
-          "preset": "hidden_value",
-          "field_value": "Shiny 90 Output ZIP"
-        },
-        {
-          "field_name": "format",
-          "label": "Format",
-          "preset": "resource_format_autocomplete",
-          "default": "ZIP"
-        },
-        {
-          "field_name": "resource_type",
-          "preset": "hidden_value",
-          "field_value": "inputs-unaids-shiny90-output-zip"
-        }
-      ]
-    },
-    {
       "name": "Naomi Output ZIP",
       "about": "The Naomi output zip file",
       "resource_type": "inputs-unaids-naomi-output-zip",


### PR DESCRIPTION
## Description

Shiny zip is no longer a required resource.

## Checklist

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request).
You may not need to check all boxes.

- [ ] The Jira ticket for this issue has been updated to "Ready to Review" or equivalent.
- [ ] I have developed these changes in discussion with the appropriate project manager.
- [ ] My code follows the general Fjelltopp documentation (see Confluence).
- [ ] I have made corresponding changes to the Fjelltopp documentation (see Confluence).
- [ ] I have rebased this branch with master.
- [ ] New dependency changes have been committed.
- [ ] I have added automated tests that prove my fix is effective or that my feature works.
- [ ] New and existing tests pass locally with my changes.
- [ ] My changes generate no new warnings.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned at least one reviewer.
