### PR TITLE
Set dataset year for 2026 datasets to 2026

### DIFF
--- a/package_schemas/country_estimates/6_country_estimates_26.json
+++ b/package_schemas/country_estimates/6_country_estimates_26.json
@@ -93,7 +93,7 @@
       "label": "Year",
       "field_name": "year",
       "preset": "hidden_value",
-      "field_value": "2025",
+      "field_value": "2026",
       "validators": "unique_combination",
       "display_group": "HIV Estimates 2026"
     },


### PR DESCRIPTION
## Description

This PR will update the "year" in 2026 dataset to actually be 2026. Think we just missed this when migrating.

I spotted this when trying to create a new 2026 dataset. For Antarctica I am getting an error message "A package already exists for: Antarctica, 2025, Country Estimates. Please update existing package." 

Not 100% sure this is the fix for the issue I am encountering but it seems about right!

<img width="1241" height="634" alt="image" src="https://github.com/user-attachments/assets/9ca28374-1d0f-43c8-a84b-3aec152d6afe" />

